### PR TITLE
feat(client.py, gateway.py): add custom websocket url support

### DIFF
--- a/client.py
+++ b/client.py
@@ -26,11 +26,16 @@ class Client():
         "https://csgoempire.link"
     ]
 
-    def __init__(self, token=None, domain="https://csgoempire.com", socket_enabled=True, socket_logger_enabled=False, engineio_logger_enabled=False):
+    def __init__(self, token=None, domain="https://csgoempire.com", ws_url=None, socket_enabled=True, socket_logger_enabled=False, engineio_logger_enabled=False):
         if token is None:
             raise ApiKeyMissing()
         if len(token) != 32:
             raise InvalidApiKey()
+        
+        self.socket_enabled = socket_enabled
+        self.socket_logger_enabled = socket_logger_enabled
+        self.engineio_logger_enabled = engineio_logger_enabled
+        self.ws_url = ws_url
 
         self.api_key = token
         self.domain = self.normalize_domain(domain)
@@ -51,7 +56,7 @@ class Client():
         # if client initialized with socket enabled, setup gateway
         if socket_enabled:
             # setup socket in background
-            self.initalise_socket(logger=socket_logger_enabled, engineio_logger=engineio_logger_enabled, domain=self.domain)
+            self.initalise_socket(logger=socket_logger_enabled, engineio_logger=engineio_logger_enabled)
 
     @staticmethod
     def normalize_domain(domain):
@@ -127,8 +132,11 @@ class Client():
     def disconnect(self):
         self.gateway.disconnect()
 
-    def initalise_socket(self, logger=False, engineio_logger=False, domain=None):
-        self.gateway = Gateway(self.api_key, self.api_base_url, logger, engineio_logger, domain)
+    def initalise_socket(self, logger=False, engineio_logger=False):
+        # use ws_url if exists, otherwise use domain
+        websocket_url = self.ws_url if self.ws_url is not None else self.domain
+        # setup gateway
+        self.gateway = Gateway(self.api_key, self.api_base_url, logger, engineio_logger, domain=websocket_url, custom_ws_url=self.ws_url is not None)
         self.socket = self.gateway.setup()
         self.events = self.gateway.get_events()
 
@@ -140,4 +148,4 @@ class Client():
         self.gateway = None
         self.socket = None
         self.events = None
-        self.initalise_socket()
+        self.initalise_socket(logger=self.socket_logger_enabled, engineio_logger=self.engineio_logger_enabled)

--- a/client.py
+++ b/client.py
@@ -31,7 +31,7 @@ class Client():
             raise ApiKeyMissing()
         if len(token) != 32:
             raise InvalidApiKey()
-        
+
         self.socket_enabled = socket_enabled
         self.socket_logger_enabled = socket_logger_enabled
         self.engineio_logger_enabled = engineio_logger_enabled

--- a/gateway.py
+++ b/gateway.py
@@ -10,7 +10,7 @@ from urllib.parse import urlparse
 
 class Gateway:
     # logger
-    def __init__(self, api_key, api_base_url, logger=False, engineio_logger=False, domain="csgoempire.com"):
+    def __init__(self, api_key, api_base_url, logger=False, engineio_logger=False, domain="csgoempire.com", custom_ws_url=False):
         """
         Constructor method for Gateway class.
 
@@ -39,9 +39,14 @@ class Gateway:
         self.debug_logger = logger
         self.debug_engineio_logger = engineio_logger
         self.last_status = None
-        # remove protocol from domain
-        self.domain = urlparse(domain).netloc
-
+        # remove protocol from domain if exists
+        parsed_url = urlparse(domain)
+        if parsed_url.scheme:
+            self.domain = parsed_url.netloc
+        else:
+            self.domain = domain
+        self.custom_websocket_url = custom_ws_url
+        
     def kill_connection(self):
         """
         Method that force kills the WebSocket connection by sending a SIGINT signal.
@@ -64,7 +69,7 @@ class Gateway:
 
             try:
                 options = {
-                    "url": f"wss://trade.{self.domain}",
+                    "url": f"wss://trade.{self.domain}" if self.custom_websocket_url is False else f"wss://{self.domain}",
                     "socketio_path": "/s/",
                     "headers": {"User-agent": user_agent},
                     "transports": ["websocket"],
@@ -72,7 +77,7 @@ class Gateway:
                 }
                 self.socket = self.sio.connect(**options)
             except Exception as e:
-                print(f"WS Connection error: {e} | {options}")
+                print(f"WS Connection error (gateway): {e} | {options}")
 
         self.sio.on("connect", handler=self.connected)
         self.sio.on("disconnect", handler=self.disconnected)

--- a/gateway.py
+++ b/gateway.py
@@ -46,7 +46,7 @@ class Gateway:
         else:
             self.domain = domain
         self.custom_websocket_url = custom_ws_url
-        
+
     def kill_connection(self):
         """
         Method that force kills the WebSocket connection by sending a SIGINT signal.


### PR DESCRIPTION
This commit introduces a new optional parameter 'ws_url' in the client initialization.
If provided, the gateway uses this URL for WebSocket communication instead of the default one.
This gives the flexibility to use custom WebSocket servers.

In the Gateway class, the domain parsing logic has been updated to account for this change.
Also, the socket initialization in the reconnect method of Client class is now reusing the parameters set during Client initialization.